### PR TITLE
Fix link: point to archived ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # overload-sig
-Discussion about discussion overload, see https://mail.python.org/mm3/mailman3/lists/overload-sig@python.org/
+Discussion about discussion overload, see https://mail.python.org/archives/list/overload-sig@python.org/latest


### PR DESCRIPTION
The overload-sig mailing list has served its purpose and been archived, and the old link no longer works.

Let's replace it with a link to the archives.

Once this is merged, please could @python/organization-owners also archive this repo to make it read-only?

GitHub archiving docs: https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories
